### PR TITLE
Support django trunk

### DIFF
--- a/compat/__init__.py
+++ b/compat/__init__.py
@@ -6,9 +6,13 @@ import inspect
 import django
 
 from django.conf import settings 
-from django.utils.importlib import import_module
-
 from django.core.exceptions import ImproperlyConfigured
+
+try:
+    from importlib import import_module
+except ImportError:  # Fallback for Python 2.6 & Django < 1.7
+    from django.utils.importlib import import_module
+
 try:
     # django 1.4.2+ , https://docs.djangoproject.com/en/1.5/topics/python3/#philosophy
     from django.utils import six


### PR DESCRIPTION
Python 2.7+ has `importlib` built-in, and Django 1.9 drops the shim completely so we need to try importing the Python built-in library first.