### PR TITLE
Added SortedDict compatibility import

### DIFF
--- a/compat/__init__.py
+++ b/compat/__init__.py
@@ -256,6 +256,11 @@ if django.VERSION < (1, 5):
     from django.utils import simplejson
 else:
     import json as simplejson
+    
+try:
+    from collections import OrderedDict as SortedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict
 
 
 # Django 1.7 compatibility


### PR DESCRIPTION
This will help with handling the removal of SortedDict in Django 1.9 and with older Python versions that lack OrderedDict.