### PR TITLE
Test on Python 2.6, 3.2, 3.3 with supported Djangos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
           env: DJANGO=django==1.8.*
 
 install:
+    - pip install -r requirements.txt
     - pip install $DJANGO
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+sudo: false
+cache: pip
 
 # Python versions supported by Django
 #       2.5 2.6 2.7   3.2 3.3 3.4 3.5 3.6
@@ -43,8 +45,8 @@ matrix:
           env: DJANGO=django==1.8.*
 
 install:
-    - pip install -r requirements.txt
-    - pip install $DJANGO
+    - pip install "pip>=7.0" wheel
+    - pip install -r requirements.txt $DJANGO
 
 script:
     python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,49 @@
 language: python
 
-python:
-    - "2.7"
-    - "3.4"
-env:
-    - DJANGO=django==1.4.*
-    - DJANGO=django==1.6.*
-    - DJANGO=django==1.7.*
-    - DJANGO=django==1.8.*
+# Python versions supported by Django
+#       2.5 2.6 2.7   3.2 3.3 3.4 3.5 3.6
+# 1.4    X   X   X
+# 1.6        X   X     X   X
+# 1.7            X     X   X   X
+# 1.8            X     X   X   X
+
+matrix:
+    include:
+        - python: 2.6
+          env: DJANGO=django==1.4.*
+        - python: 2.6
+          env: DJANGO=django==1.6.*
+
+        - python: 2.7
+          env: DJANGO=django==1.4.*
+        - python: 2.7
+          env: DJANGO=django==1.6.*
+        - python: 2.7
+          env: DJANGO=django==1.7.*
+        - python: 2.7
+          env: DJANGO=django==1.8.*
+
+        - python: 3.2
+          env: DJANGO=django==1.6.*
+        - python: 3.2
+          env: DJANGO=django==1.7.*
+        - python: 3.2
+          env: DJANGO=django==1.8.*
+
+        - python: 3.3
+          env: DJANGO=django==1.6.*
+        - python: 3.3
+          env: DJANGO=django==1.7.*
+        - python: 3.3
+          env: DJANGO=django==1.8.*
+
+        - python: 3.4
+          env: DJANGO=django==1.7.*
+        - python: 3.4
+          env: DJANGO=django==1.8.*
 
 install:
     - pip install $DJANGO
 
 script:
     python runtests.py
-
-matrix:
-    exclude:
-        - python: "3.4"
-          env: DJANGO=django==1.4.*

--- a/compat/__init__.py
+++ b/compat/__init__.py
@@ -36,10 +36,10 @@ except ImportError:
 
 
 # get_indent
-if six.PY3:
+try:
     from threading import get_ident
-else:
-    from thread import get_ident  # noqa
+except ImportError:
+    from six.moves._thread import get_ident  # noqa
 
 try:
     from django.conf.urls import url, patterns, include, handler404, handler500

--- a/compat/tests/test_compat.py
+++ b/compat/tests/test_compat.py
@@ -13,7 +13,7 @@ from .models import UnimportantThing
 class CompatTests(TestCase):
 
     def test_compat(self):
-        from importlib import import_module
+        from compat import import_module
         from compat import __all__
 
         compat = import_module('compat')
@@ -35,7 +35,7 @@ class CompatTests(TestCase):
         from compat import format_html
 
         self.assertEqual(
-            format_html("{} {} {third} {fourth}",
+            format_html("{0} {1} {third} {fourth}",
                              "< Dangerous >",
                              html.mark_safe("<b>safe</b>"),
                              third="< dangerous again",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+# To run the unit tests against multiple python versions you will need
+# the necessary python versions installed, and Tox.
+#   pip install tox
+#   tox
+
+[tox]
+envlist =
+    py27-django14,
+    py27-django16,
+    py27-django17,
+    py27-django18,
+    py34-django16,
+    py34-django17,
+    py34-django18,
+
+[testenv]
+deps =
+    -rrequirements.txt
+    django14: Django>=1.4,<1.5
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+commands =
+    python runtests.py

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,22 @@
 
 [tox]
 envlist =
+    py26-django14,
+    py26-django16,
+
     py27-django14,
     py27-django16,
     py27-django17,
     py27-django18,
+
+    py32-django16,
+    py32-django17,
+    py32-django18,
+
+    py33-django16,
+    py33-django17,
+    py33-django18,
+
     py34-django16,
     py34-django17,
     py34-django18,


### PR DESCRIPTION
NB: This includes the Tox support added by #32

- Fix `compat.get_ident()` on Python 3.2
- Fix `compat.tests.test_compat.CompatTests.test_compat()` on Python 2.6
- Fix `compat.tests.test_compat.CompatTests.test_format_html()` on Python 2.6

NB: This doesn't include Python 2.5, even though it's supported by Django 1.4