### PR TITLE
Add Django 2.0 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
   - python: "3.5"
     env:
       - TOX_ENV=py35-django111
+  - python: "3.5"
+    env: TOX_ENV=py35-django20
   - python: "3.6"
     env:
       - TOX_ENV=py36-django18
@@ -36,6 +38,14 @@ matrix:
   - python: "3.6"
     env:
       - TOX_ENV=py36-django111
+  - python: "3.6"
+    env: TOX_ENV=py36-django20
+
+  allow_failures:
+    - python: "3.5"
+      env: TOX_ENV=py35-django20
+    - python: "3.6"
+      env: TOX_ENV=py36-django20
 
 install:
     - pip install tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist =
-    py{27,35,36}-django{18,19,110,111},
+    py{27,35,36}-django{18,19,110,111,20},
 
 [testenv]
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.1,<1.10
     django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<1.12
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0a1,<2.1
     -r{toxinidir}/requirements-test.txt
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Django 2.0a1 is released, adding it to the build matrix to test. Allow it to fail for now.