### PR TITLE
Update __init__.py

### DIFF
--- a/compat/__init__.py
+++ b/compat/__init__.py
@@ -43,7 +43,8 @@ except ImportError:
     from six.moves._thread import get_ident  # noqa
 
 try:
-    from django.conf.urls import url, include, handler404, handler500
+    from django.conf.urls import url, handler404, handler500
+    from django.urls import include
 except ImportError:
     from django.conf.urls.defaults import url, include, handler404, handler500  # pyflakes:ignore
 


### PR DESCRIPTION
The try/except block here is failing for the most recent version of Django.

It's trying to import include from django.conf.urls and then failing into the ImportError exception which then causes a compilation error when it tries to import from django.conf.urls.default since that no longer exists.